### PR TITLE
feat: detect http requests with proxy server

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,17 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"god/proxy"
+	"log"
+)
 
 func main() {
 	fmt.Println("Hello, G.O.D!")
+
+	// Proxy server start (temp)
+	// Forward Proxy command (window) : curl -x http://127.0.0.1:8083 http://httpbin.org/get
+	if err := proxy.Start("127.0.0.1:8083"); err != nil {
+		log.Fatalf("Proxy faild: %v", err)
+	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"runtime"
+	"time"
+)
+
+// LoggingResponseWriter wraps http.ResponseWriter to capture status code and bytes written.
+type LoggingResponseWriter struct {
+	http.ResponseWriter
+	StatusCode   int
+	BytesWritten int
+}
+
+func (lrw *LoggingResponseWriter) WriteHeader(code int) {
+	lrw.StatusCode = code
+	lrw.ResponseWriter.WriteHeader(code)
+}
+
+func (lrw *LoggingResponseWriter) Write(b []byte) (int, error) {
+	n, err := lrw.ResponseWriter.Write(b)
+	lrw.BytesWritten += n
+	return n, err
+}
+
+// Start Initialize and run proxy servers
+func Start(listenAddr string) error {
+	proxy := &httputil.ReverseProxy{
+		// modifying requests with Director
+		Director: func(req *http.Request) {
+			// record request start time in header
+			req.Header.Set("X-Start-Time", time.Now().UTC().Format(time.RFC3339Nano))
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startTime := time.Now()
+		lrw := &LoggingResponseWriter{ResponseWriter: w, StatusCode: http.StatusOK}
+
+		destination := r.URL
+		if !destination.IsAbs() {
+			http.Error(lrw, "Absolute URL required", http.StatusBadRequest)
+			return
+		}
+		r.Host = destination.Host
+
+		// lrw include http.ResponseWriter
+		proxy.ServeHTTP(lrw, r)
+
+		duration := time.Since(startTime)
+		// memory check
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+
+		// structured JSON style log
+		log.Printf(
+			`{"method":"%s","url":"%s","startTime":"%s","durationMs":%d,"status":%d,"bytes":%d,"memAlloc":%d}`,
+			r.Method,
+			r.URL.String(),
+			startTime.UTC().Format(time.RFC3339Nano),
+			duration.Milliseconds(),
+			lrw.StatusCode,
+			lrw.BytesWritten,
+			m.Alloc,
+		)
+	})
+
+	log.Printf("Starting HTTP proxy at %s", listenAddr)
+	return http.ListenAndServe(listenAddr, handler)
+}

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"god/proxy"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"net/http/httputil"
+)
+
+func TestProxy_Start(t *testing.T) {
+	// Create a test server to act as the backend
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Backend", "ok")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("backend response"))
+	}))
+	defer backend.Close()
+
+	// Start the proxy server using httptest
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startTime := time.Now()
+		lrw := &proxy.LoggingResponseWriter{ResponseWriter: w, StatusCode: http.StatusOK}
+
+		destination := r.URL
+		if !destination.IsAbs() {
+			http.Error(lrw, "Absolute URL required", http.StatusBadRequest)
+			return
+		}
+		r.Host = destination.Host
+
+		p := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				u, _ := url.Parse(backend.URL)
+				req.URL.Scheme = u.Scheme
+				req.URL.Host = u.Host
+				req.Header.Set("X-Start-Time", time.Now().UTC().Format(time.RFC3339Nano))
+			},
+		}
+		p.ServeHTTP(lrw, r)
+
+		_ = time.Since(startTime) // duration measurement skipped
+	}))
+	defer proxyServer.Close()
+
+	// Send a request to the proxy server
+	client := &http.Client{}
+	// Create a request with an absolute URL
+	u, _ := url.Parse(backend.URL)
+	req, err := http.NewRequest("GET", proxyServer.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.URL.Scheme = u.Scheme
+	req.URL.Host = u.Host
+	req.URL.Path = "/"
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "backend response" {
+		t.Errorf("unexpected response body: %s", string(body))
+	}
+	if resp.Header.Get("X-Backend") != "ok" {
+		t.Errorf("missing or wrong backend header: %s", resp.Header.Get("X-Backend"))
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
### 신규 기능
프록시 서버 띄워서 해당 프록시 서버를 거치는 요청들은 log로 남게 구성

### log 형식
 {"method":"GET","url":"http://httpbin.org/get","startTime":"2025-07-16T05:54:42.6978478Z","durationMs":1593,"status":200,"bytes":350,"memAlloc":490096}

### log 정보 
- method : http method
- url : client request url
- startTime : 요청 처리 시작 시각
- durationMs : 요청에 걸린 시간
- status : http 상태코드
- bytes : 프록시가 클라이언트에게 실제로 전송한 바이트 수 
- memAlloc : 로그 시점의 Go 런타임 메모리 할당량(바이트 단위, runtime.MemStats.Alloc)
