### PR TITLE
feat: 로컬 json 데이터 저장 추가

### DIFF
--- a/data/localMetric.go
+++ b/data/localMetric.go
@@ -1,0 +1,49 @@
+package data
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+)
+
+type JsonMetric struct {
+	mu      *sync.RWMutex
+	metrics map[string][]DataPoint
+	path    string
+}
+
+func NewJsonMetric(path string) *JsonMetric {
+	return &JsonMetric{
+		metrics: make(map[string][]DataPoint),
+		path:    path,
+	}
+}
+
+func (m *JsonMetric) Record(metricName string, value string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.metrics[metricName]; !ok {
+		m.metrics[metricName] = []DataPoint{}
+	}
+
+	m.metrics[metricName] = append(m.metrics[metricName], DataPoint{
+		Timestamp: time.Now(),
+		Value:     value,
+	})
+}
+
+func (m *JsonMetric) Flush() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	file, err := os.Create(m.path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	return encoder.Encode(m.metrics)
+}

--- a/data/metric.go
+++ b/data/metric.go
@@ -1,0 +1,15 @@
+package data
+
+import "time"
+
+type Metic interface {
+	// Record 매트릭 수집 처리
+	Record(metricName string, value float64)
+	// Flush 매트릭 저장 처리
+	Flush() error
+}
+
+type DataPoint struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     string    `json:"value"`
+}


### PR DESCRIPTION
JsonMetric 타입을 추가하여 metric 데이터를 메모리에 기록하고
주기적으로 로컬 파일(JSON)로 flush할 수 있는 기능을 구현.

- Metric 데이터 구조:
  - metricName(string)별로 DataPoint 목록으로 관리
  - DataPoint: timestamp + value 쌍으로 구성

- Record(metricName, value):
  - metricName으로 metric을 등록 및 갱신
  - value를 DataPoint로 기록 (timestamp 포함)

- Flush():
  - 현재 메모리상의 metrics 데이터를 JSON 파일로 직렬화하여 저장

추후 확장 계획:
- backend로 InfluxDB 등 추가 가능하도록 개선 예정